### PR TITLE
Relay weapon changes so remote players show their equipped weapon

### DIFF
--- a/TcpServer/Program.cs
+++ b/TcpServer/Program.cs
@@ -217,6 +217,22 @@ class TcpServer
             case 0: // Change weapon
                 int weaponId = buffer.GetInt();
                 Console.WriteLine($"Player \"{id}\" changed weapon to \"{weaponId}\"");
+                lock (playerDatas)
+                {
+                    if (playerDatas.TryGetValue(id, out var weaponPlayer))
+                    {
+                        weaponPlayer.weapon = weaponId;
+                        weaponPlayer.weaponChanged = true;
+                    }
+                }
+                // relay so other clients render the weapon on this player's avatar
+                // (client handles protocol 2 / argument 2 -> PlayerChangeWeapon(id, weaponId))
+                ByteBuffer weaponBroadcast = new ByteBuffer();
+                weaponBroadcast.Put((byte)2); // protocol
+                weaponBroadcast.Put((byte)2); // argument 2 = change weapon
+                weaponBroadcast.Put(id);
+                weaponBroadcast.Put(weaponId);
+                SendToOtherClients(weaponBroadcast.Trim().Get(), id);
                 break;
 
             case 1: // Fire weapon


### PR DESCRIPTION
## Problem
The `change weapon` action (`HandleGameActions` case 0) was **log-only**  it printed the weapon change but never told other clients. So remote players' avatars rendered **no weapon**.

## Fix
Store the player's weapon server-side and **relay it** as `protocol 2 / argument 2`. The client already handles this (`Client.PlayerChangeWeapon → NetworkPlayer.EquipWeapon`), so **no client change is needed**.

## Testing
Two clients in a match: switching/equipping a weapon now shows on the other player's avatar. Verified live.

## Known limitation (follow-up)
A player who joins **after** another equipped won't see that weapon until the equipped player switches again  the handshake doesn't send current weapons, only changes are relayed. A small follow-up can replay current weapons to new joiners.

